### PR TITLE
Fix deprecated splat operator usage in util.cr macro

### DIFF
--- a/src/chipmunk/util.cr
+++ b/src/chipmunk/util.cr
@@ -50,9 +50,9 @@ macro _cp_gather(name, f)
 
   {{f}}
 
-  def {% if f.receiver %}{{f.receiver}}.{% end %}{{name}}({{*f.args}}) : Array({{typ}})
+  def {% if f.receiver %}{{f.receiver}}.{% end %}{{name}}({{f.args.splat}}) : Array({{typ}})
     result = [] of {{typ}}
-    {{f.name}}({{*f.args.map &.internal_name}}) do |item|
+    {{f.name}}({{f.args.map(&.internal_name).splat}}) do |item|
       result << item
     end
     result


### PR DESCRIPTION
This pull request will removes the following warnings.
Thank you.

`crystal build examples/hello.cr`


```console
In src/chipmunk/util.cr:52:62

 52 | def {% if f.receiver %}{{f.receiver}}.{% end %}{{name}}({{*f.args}}) : Array({{typ}})
                                                                 ^
Warning: Deprecated use of splat operator. Use `#splat` instead

In src/chipmunk/util.cr:54:19

 54 | {{f.name}}({{*f.args.map &.internal_name}}) do |item|
                    ^
Warning: Deprecated use of splat operator. Use `#splat` instead

In src/chipmunk/util.cr:52:62

 52 | def {% if f.receiver %}{{f.receiver}}.{% end %}{{name}}({{*f.args}}) : Array({{typ}})
                                                                 ^
Warning: Deprecated use of splat operator. Use `#splat` instead

In src/chipmunk/util.cr:54:19

 54 | {{f.name}}({{*f.args.map &.internal_name}}) do |item|
                    ^
Warning: Deprecated use of splat operator. Use `#splat` instead

In src/chipmunk/util.cr:52:62

 52 | def {% if f.receiver %}{{f.receiver}}.{% end %}{{name}}({{*f.args}}) : Array({{typ}})
                                                                 ^
Warning: Deprecated use of splat operator. Use `#splat` instead

In src/chipmunk/util.cr:54:19

 54 | {{f.name}}({{*f.args.map &.internal_name}}) do |item|
                    ^
Warning: Deprecated use of splat operator. Use `#splat` instead

In src/chipmunk/util.cr:52:62

 52 | def {% if f.receiver %}{{f.receiver}}.{% end %}{{name}}({{*f.args}}) : Array({{typ}})
                                                                 ^
Warning: Deprecated use of splat operator. Use `#splat` instead

In src/chipmunk/util.cr:54:19

 54 | {{f.name}}({{*f.args.map &.internal_name}}) do |item|
                    ^
Warning: Deprecated use of splat operator. Use `#splat` instead

In src/chipmunk/util.cr:52:62

 52 | def {% if f.receiver %}{{f.receiver}}.{% end %}{{name}}({{*f.args}}) : Array({{typ}})
                                                                 ^
Warning: Deprecated use of splat operator. Use `#splat` instead

In src/chipmunk/util.cr:54:19

 54 | {{f.name}}({{*f.args.map &.internal_name}}) do |item|
                    ^
Warning: Deprecated use of splat operator. Use `#splat` instead

In src/chipmunk/util.cr:52:62

 52 | def {% if f.receiver %}{{f.receiver}}.{% end %}{{name}}({{*f.args}}) : Array({{typ}})
                                                                 ^
Warning: Deprecated use of splat operator. Use `#splat` instead

In src/chipmunk/util.cr:54:19

 54 | {{f.name}}({{*f.args.map &.internal_name}}) do |item|
                    ^
Warning: Deprecated use of splat operator. Use `#splat` instead

In src/chipmunk/util.cr:52:62

 52 | def {% if f.receiver %}{{f.receiver}}.{% end %}{{name}}({{*f.args}}) : Array({{typ}})
                                                                 ^
Warning: Deprecated use of splat operator. Use `#splat` instead

In src/chipmunk/util.cr:54:19

 54 | {{f.name}}({{*f.args.map &.internal_name}}) do |item|
                    ^
Warning: Deprecated use of splat operator. Use `#splat` instead

A total of 14 warnings were found.
```